### PR TITLE
missing redis default listen addr

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -169,6 +169,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "redis-host, rH",
 			Usage:  "hostname of the redis service",
+			Value:  "127.0.0.1",
 			EnvVar: "REDIS_MASTER_SERVICE_HOST, REDIS_SERVICE_HOST",
 		},
 		cli.IntFlag{
@@ -242,7 +243,7 @@ func main() {
 			log.WithError(err).Error("Got GRPC error")
 			return err
 		}
-		log.Info("Shooting down... at last!")
+		log.Info("Shutting down... at last!")
 		return nil
 	}
 	err := app.Run(os.Args)


### PR DESCRIPTION
missing redis default listen addr

if we start server without any parameters, it will fail  to start
```sh
./server.exe
{"error":"No redis host defined","message":"Failed to serve application","severity":"fatal","timestamp":"2021-01-20T15:59:12.0957417+08:00"}
```
unless we specify redis addr like this
```sh
$ ./server.exe --redis-host 127.0.0.1  --redis-port 6379 --redis-db 0
{"addr":":50051","message":"Start listening","severity":"info","timestamp":"2021-01-20T16:05:45.4161893+08:00"}
{"addr":":50051","message":"Got syscall","severity":"info","signal":2,"timestamp":"2021-01-20T16:07:03.3151535+08:00"}
{"addr":":50051","message":"Shooting down... at last!","severity":"info","timestamp":"2021-01-20T16:07:03.3151535+08:00"}
```


